### PR TITLE
Add the company name in the licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,18 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 MIDDLEWARE SOLUTIONS SARL, France
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Actually the company name is never written in any document stored on the repository. This PR fix that by adding the company name in the Apache 2.0 licence.

Unique change:

- From: `Copyright [yyyy] [name of copyright owner]`
- To: `Copyright 2019 MIDDLEWARE SOLUTIONS SARL, France`